### PR TITLE
fix(archive): 'Thank your or subscribing' -> 'Thank you for subscribing' in issues 3-5

### DIFF
--- a/src/archive/3.md
+++ b/src/archive/3.md
@@ -385,5 +385,5 @@ This is Andon, automated: nothing gets to production if anything is going to bre
 - Fabulous spin class this morning. High intensity, felt good. [→](http://www.thingelstad.com/2017/05/20/fabulous-spin-class.html)
 ## The end 🎬
 
-Thank your or subscribing. If you know of people that would like the Weekly Thing please forward it to them and spread the word!
+Thank you for subscribing. If you know of people that would like the Weekly Thing please forward it to them and spread the word!
 {% endraw %}

--- a/src/archive/4.md
+++ b/src/archive/4.md
@@ -303,5 +303,5 @@ Nice improvements in a very solid drawing app for the iPad Pro.
 - Ringer! #horseshoes [→](http://www.thingelstad.com/2017/05/27/161054.html)
 ## The end 🎬
 
-Thank your or subscribing. If you know of people that would like the [Weekly Thing](http://weekly.thingelstad.com) please forward it to them and spread the word! The [archive](http://tinyletter.com/thingelstad/archive) is also available to see this and all past issues.
+Thank you for subscribing. If you know of people that would like the [Weekly Thing](http://weekly.thingelstad.com) please forward it to them and spread the word! The [archive](http://tinyletter.com/thingelstad/archive) is also available to see this and all past issues.
 {% endraw %}

--- a/src/archive/5.md
+++ b/src/archive/5.md
@@ -362,5 +362,5 @@ Cloud technology is making technology teams thing about costs in a different way
 - Very long escalator @ Guthrie Theatre. [→](http://www.thingelstad.com/2017/06/03/very-long-escalator.html)
 ## The end 🎬
 
-Thank your or subscribing. If you know of people that would like the Weekly Thing please forward it to them and spread the word!
+Thank you for subscribing. If you know of people that would like the Weekly Thing please forward it to them and spread the word!
 {% endraw %}


### PR DESCRIPTION
## Summary

Per #7, the Tinyletter-era closing line \"Thank your or subscribing.\" appears in issues 3, 4, and 5. Ran the fix the issue proposed:

\`\`\`bash
for n in 3 4 5; do
  sed -i '' 's|Thank your or subscribing\\.|Thank you for subscribing.|' src/archive/\$n.md
done
\`\`\`

Left the Buttondown sync for the maintainer — this PR only touches the source markdown.

Closes #7

## Testing

After the fix \`grep 'Thank your or subscribing' src/archive/\` returns nothing.